### PR TITLE
Show the cursor most of the time

### DIFF
--- a/src/DefragPrinter.php
+++ b/src/DefragPrinter.php
@@ -73,9 +73,9 @@ class DefragPrinter
             + 7 // status, legend
             + 1; // bottom
 
-        $this->writeAll();
-
         $this->hideCursor();
+
+        $this->writeAll();
     }
 
     private function completeTest($sector = Sector::PASSED): void

--- a/src/Traits/WritesOutput.php
+++ b/src/Traits/WritesOutput.php
@@ -13,6 +13,8 @@ trait WritesOutput
 
     private function writeOutput($output): void
     {
+        $this->hideCursor();
+
         $lines = explode(PHP_EOL, $output);
 
         if ($this->lastOutput) {
@@ -30,6 +32,8 @@ trait WritesOutput
         $this->lastOutput = $lines;
 
         $this->moveCursor(0, count($lines) - $lastIndex - 1);
+
+        $this->showCursor();
     }
 
     protected static function writeDirectly(string $message): void


### PR DESCRIPTION
This will show the cursor below the output, which is gross, but will avoid ^C dropping you to a cursor-less prompt.

I couldn't find a PHPUnit eventt for this situation. `TestRunner\ExecutionAborted` doesn't work.
