### PR TITLE
Prevent installing alongside incompatible PHPUnit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,13 +16,13 @@
         }
     ],
     "require": {
-        "php": "^8.1"
+        "php": "^8.1",
+        "illuminate/collections": "^10.0|^11.0",
+        "laravel/prompts": "^0.1",
+        "phpunit/phpunit": "^10.3"
     },
     "require-dev": {
-        "illuminate/collections": "^10.0|^11.0",
         "laravel/pint": "^1.0",
-        "laravel/prompts": "^0.1",
-        "phpunit/phpunit": "^10.3",
         "symfony/console": "^6.0"
     },
     "autoload": {


### PR DESCRIPTION
Hi there! 

I've just found this package and went to install it, but I couldn't immediately tell that PHPUnit 9 is incompatible. Only after a few minutes of troubleshooting did I learn that. (Though really I should just upgrade that project soon 🙃)

This PR makes `phpunit/phpunit` a production dependency so that Composer will complain about incompatible versions on installation.

The same is done for `illuminate/collections` and `laravel/prompts`, because DefragPrinter directly calls code from these packages in runtime. This is needed for this extension to work in non-Laravel projects.

Thank you for creating this package. The way that the cells move around the screen during tests seems so realistic, I love it!